### PR TITLE
Feat/user channel junction

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,5 +46,6 @@ In order for the project to connect correctly to the supabase database:
 
 ## Documentation
 
-- Supabase: [docs](https://supabase.io/docs) & [javascript client](https://supabase.io/docs/reference/javascript/supabase-client)
-- React.js: [docs](https://reactjs.org/docs/getting-started.html)
+- [Supabase](https://supabase.io/docs) & [Supabase JavaScript client](https://supabase.io/docs/reference/javascript/supabase-client)
+- [PostgreSQL Policies](https://www.postgresql.org/docs/current/sql-createpolicy.html)
+- [React.js](https://reactjs.org/docs/getting-started.html)

--- a/sql/init.sql
+++ b/sql/init.sql
@@ -3,8 +3,8 @@ DROP TABLE user_channel, channels, users;
 -- Create a table for public "users"
 create table users (
 	id uuid references auth.users not null,
-	updated_at timestamp with time zone,
-	created_at timestamp with time zone,
+	created_at timestamp with time zone default CURRENT_TIMESTAMP,
+	updated_at timestamp with time zone default CURRENT_TIMESTAMP,
 	primary key (id)
 );
 
@@ -25,10 +25,10 @@ create policy "Users can update own user."
 -- Create a table for public "channels"
 create table channels (
 	id uuid DEFAULT gen_random_uuid() primary key,
-	name text,
-	slug text unique,
-	updated_at timestamp with time zone,
-	created_at timestamp with time zone,
+	name text not null,
+	slug text unique not null,
+	created_at timestamp with time zone default CURRENT_TIMESTAMP,
+	updated_at timestamp with time zone default CURRENT_TIMESTAMP,
 	url text,
 	user_id uuid references auth.users(id) not null,
 	unique(slug),
@@ -58,8 +58,8 @@ create policy "Users can delete own channel."
 create table user_channel (
 	user_id uuid not null references auth.users (id) on delete cascade,
 	channel_id uuid not null references channels (id) on delete cascade,
-	created_at timestamp with time zone,
-	updated_at timestamp with time zone,
+	created_at timestamp with time zone default CURRENT_TIMESTAMP,
+	updated_at timestamp with time zone default CURRENT_TIMESTAMP,
 	PRIMARY KEY (user_id, channel_id)
 );
 
@@ -97,3 +97,13 @@ AS $$
 	 delete from channels where user_id = auth.uid();
    delete from auth.users where id = auth.uid();
 $$;
+
+-- Automatically update "updated_at" timestamps
+create extension if not exists moddatetime schema extensions;
+-- this trigger will set the "updated_at" column to the current timestamp for every update
+create trigger user_update before update on users
+  for each row execute procedure moddatetime (updated_at);
+create trigger channel_update before update on channels
+  for each row execute procedure moddatetime (updated_at);
+create trigger user_channel_update before update on user_channel
+  for each row execute procedure moddatetime (updated_at);

--- a/sql/init.sql
+++ b/sql/init.sql
@@ -1,4 +1,4 @@
-DROP TABLE channels, users;
+DROP TABLE user_channel, channels, users;
 
 -- Create a table for public "users"
 create table users (
@@ -52,6 +52,33 @@ create policy "Users can update own channel."
 
 create policy "Users can delete own channel."
 	on channels for delete
+	using ( auth.uid() = user_id );
+
+-- Create junction table for user >< channel
+create table user_channel (
+	user_id uuid not null references auth.users (id) on delete cascade,
+	channel_id uuid not null references channels (id) on delete cascade,
+	created_at timestamp with time zone,
+	updated_at timestamp with time zone,
+	PRIMARY KEY (user_id, channel_id)
+);
+
+alter table user_channel enable row level security;
+
+create policy "User channel junctions are viewable by everyone"
+	on user_channel for select
+	using ( true );
+
+create policy "User can insert their junction."
+	on user_channel for insert
+	with check ( auth.uid() = user_id );
+
+create policy "Users can update own junction."
+	on user_channel for update
+	using ( auth.uid() = user_id );
+
+create policy "Users can delete own junction."
+	on user_channel for delete
 	using ( auth.uid() = user_id );
 
 -- Set up Realtime!

--- a/src/components/channel-forms.js
+++ b/src/components/channel-forms.js
@@ -10,13 +10,14 @@ export function CreateForm({onSubmit, channel = {}}) {
 		try {
 			setLoading(true)
 			res = await onSubmit(form)
+			console.log(res)
 			if (res && res.error) throw res.error
 		} catch (error) {
 			console.log(error)
+			throw error
 		} finally {
 			setLoading(false)
 		}
-		return res
 	}
 
 	return (
@@ -27,6 +28,7 @@ export function CreateForm({onSubmit, channel = {}}) {
 				<input
 				id="name"
 				type="text"
+				autoFocus={true}
 				required
 					onChange={(e) => setForm({...form, [e.target.id]: e.target.value})}
 				/>

--- a/src/pages/channels.js
+++ b/src/pages/channels.js
@@ -5,7 +5,7 @@ const PageChannels = ({dbSession: {database}}) => {
 
 	if (!database) return null
 
-	if (!channels) return <p>No channels</p>
+	if (!channels.length) return <p>No channels</p>
 	return channels.map(channel => {
 		return (
 			<article key={channel.id}>

--- a/src/utils/crud/channel.js
+++ b/src/utils/crud/channel.js
@@ -1,14 +1,11 @@
 export const createChannel = async ({database, channel, user}) => {
 	const {name, slug} = channel
 	const {id: user_id} = user
-	const now = new Date()
 
 	// Create channel
 	const res = await database
 		.from('channels')
 		.insert({
-			created_at: now,
-			updated_at: now,
 			name,
 			slug,
 			user_id,
@@ -22,8 +19,6 @@ export const createChannel = async ({database, channel, user}) => {
 	return database
 		.from('user_channel')
 		.insert({
-			created_at: now,
-			updated_at: now,
 			user_id,
 			channel_id: res.data.id,
 		})
@@ -37,7 +32,6 @@ export const updateChannel = async ({database, channel}) => {
 		.update({
 			name,
 			slug,
-			updated_at: new Date(),
 		})
 		.eq('id', id)
 		.single()

--- a/src/utils/crud/channel.js
+++ b/src/utils/crud/channel.js
@@ -1,43 +1,51 @@
-const createChannel = async ({database, channel, user}) => {
+export const createChannel = async ({database, channel, user}) => {
 	const {name, slug} = channel
 	const {id: user_id} = user
 	const now = new Date()
 
-	return database
+	// Create channel
+	const res = await database
 		.from('channels')
 		.insert({
+			created_at: now,
+			updated_at: now,
 			name,
 			slug,
 			user_id,
+		})
+		.single()
+
+	// Avoid touching next query (return early) if it did not succeed.
+	if (res.error) return res
+
+	// Create junction table
+	return database
+		.from('user_channel')
+		.insert({
 			created_at: now,
-			updated_at: now
+			updated_at: now,
+			user_id,
+			channel_id: res.data.id,
 		})
 		.single()
 }
 
-const updateChannel = async ({database, channel}) => {
+export const updateChannel = async ({database, channel}) => {
 	const {id, name, slug} = channel
 	return database
 		.from('channels')
 		.update({
 			name,
 			slug,
-			updated_at: new Date()
-		}).eq('id', id).single()
+			updated_at: new Date(),
+		})
+		.eq('id', id)
+		.single()
 }
 
-const deleteChannel = async ({database, channel}) => {
+export const deleteChannel = async ({database, channel}) => {
 	const {id} = channel
 	console.log(channel)
 	if (!id) return
-
-	return database
-		.from('channels')
-		.delete().match({id})
-}
-
-export {
-	createChannel,
-	updateChannel,
-	deleteChannel
+	return database.from('channels').delete().match({id})
 }


### PR DESCRIPTION
Wait for #22 to be merged first.

- adds a new `user_channel` table
- creates the row in the db from the front-end when you create a channel
- is automatically deleted (by postgres) with the channel
- `created_at` and `updated_at` are now set automatically with Postgres

I did not touch any custom "roles" or such and there are some supabase-supported "auth.role" thing available as well https://supabase.io/docs/learn/auth-deep-dive/auth-row-level-security

Closes #7 
Closes #20 