### PR TITLE
Refactor channel+track forms with useForm hook

### DIFF
--- a/src/components/channel-forms.js
+++ b/src/components/channel-forms.js
@@ -9,12 +9,11 @@ function useForm(initialState, {onSubmit}) {
 	const bind = (e) => setForm({...form, [e.target.id]: e.target.value})
 
 	async function handleSubmit(event) {
-		event.preventDefault()
-		let res
+		event?.preventDefault()
 		try {
 			setLoading(true)
 			console.log('submitting', form)
-			res = await onSubmit(form)
+			const res = await onSubmit(form)
 			console.log(res)
 			if (res && res.error) {
 				setError(res.error)
@@ -77,36 +76,22 @@ export function UpdateForm({channel, onSubmit}) {
 }
 
 export function DeleteForm({channel, onSubmit}) {
-	const [loading, setLoading] = useState(false)
-	const [form, setForm] = useState({})
+	const {form, loading, error, bind, handleSubmit} = useForm({}, {onSubmit})
 
-	function confirmDelete() {
-		return window.confirm('Confirm you want to delete your channel')
-	}
-
-	const handleSubmit = async (e) => {
-		e.preventDefault()
-		setLoading(true)
-		if (!confirmDelete()) {
-			setLoading(false)
-			return
-		}
-
-		let res
+	const confirmDelete = async (event) => {
+		event.preventDefault()
+		const didConfirm = window.confirm('Confirm you want to delete your channel')
+		if (!didConfirm) return
 		try {
-			res = await onSubmit(channel)
-			if (res && res.error) throw res.error
-			console.log('deleted channel')
+			await handleSubmit()
 			window.location.reload()
-		} catch (error) {
-			console.log(error)
-		} finally {
-			setLoading(false)
+		} catch (err) {
+			console.log('no delete?')
 		}
 	}
 
 	return (
-		<form onSubmit={handleSubmit}>
+		<form onSubmit={confirmDelete}>
 			<p>
 				To delete your channel, confirm by writing <em>"{channel.slug}"</em>:
 			</p>
@@ -117,13 +102,13 @@ export function DeleteForm({channel, onSubmit}) {
 					placeholder={`${channel.slug}`}
 					value={form.slug}
 					required
-					onChange={(e) => setForm({...form, [e.target.id]: e.target.value})}
+					onChange={bind}
 				/>
 				<button type="submit" disabled={loading || channel.slug !== form.slug} danger="true">
 					{loading ? 'Loading...' : 'Delete channel'}
 				</button>
 			</p>
-			{/* <ErrorDisplay error={error}></ErrorDisplay> */}
+			<ErrorDisplay error={error}></ErrorDisplay>
 		</form>
 	)
 }

--- a/src/components/channel-forms.js
+++ b/src/components/channel-forms.js
@@ -57,7 +57,7 @@ export function DeleteForm({channel, onSubmit}) {
 			await handleSubmit()
 			window.location.reload()
 		} catch (err) {
-			console.log('no delete?')
+			console.error('Could not delete channel')
 		}
 	}
 

--- a/src/components/channel-forms.js
+++ b/src/components/channel-forms.js
@@ -1,34 +1,5 @@
-import {useState} from 'react'
+import useForm from '../hooks/use-form'
 import ErrorDisplay from './error-display'
-
-function useForm(initialState, {onSubmit}) {
-	const [form, setForm] = useState(initialState)
-	const [loading, setLoading] = useState(false)
-	const [error, setError] = useState(false)
-
-	const bind = (e) => setForm({...form, [e.target.id]: e.target.value})
-
-	async function handleSubmit(event) {
-		event?.preventDefault()
-		try {
-			setLoading(true)
-			console.log('submitting', form)
-			const res = await onSubmit(form)
-			console.log(res)
-			if (res && res.error) {
-				setError(res.error)
-			} else {
-				setError(false)
-			}
-		} catch (error) {
-			setError(error)
-		} finally {
-			setLoading(false)
-		}
-	}
-
-	return {form, loading, error, bind, handleSubmit}
-}
 
 export function CreateForm({onSubmit}) {
 	const {form, loading, error, bind, handleSubmit} = useForm({}, {onSubmit})

--- a/src/components/channel-forms.js
+++ b/src/components/channel-forms.js
@@ -1,17 +1,21 @@
 import {useState} from 'react'
 import ErrorDisplay from './error-display'
 
-export function CreateForm({onSubmit, channel = {}}) {
+function useForm(initialState, {onSubmit}) {
+	const [form, setForm] = useState(initialState)
 	const [loading, setLoading] = useState(false)
-	const [form, setForm] = useState({})
-	const [error, setError] = useState()
+	const [error, setError] = useState(false)
 
-	const handleSubmit = async (e) => {
-		e.preventDefault()
+	const bind = (e) => setForm({...form, [e.target.id]: e.target.value})
+
+	async function handleSubmit(event) {
+		event.preventDefault()
 		let res
 		try {
 			setLoading(true)
+			console.log('submitting', form)
 			res = await onSubmit(form)
+			console.log(res)
 			if (res && res.error) {
 				setError(res.error)
 			} else {
@@ -24,27 +28,21 @@ export function CreateForm({onSubmit, channel = {}}) {
 		}
 	}
 
+	return {form, loading, error, bind, handleSubmit}
+}
+
+export function CreateForm({onSubmit}) {
+	const {form, loading, error, bind, handleSubmit} = useForm({}, {onSubmit})
+
 	return (
 		<form onSubmit={handleSubmit}>
 			<h3>Create channel</h3>
 			<p>
 				<label htmlFor="name">What would you like to call your radio channel?</label>
-				<input
-					id="name"
-					type="text"
-					autoFocus={true}
-					required
-					onChange={(e) => setForm({...form, [e.target.id]: e.target.value})}
-				/>
+				<input id="name" type="text" autoFocus={true} required onChange={bind} />
 				<br />
 				<label htmlFor="slug">And the slug? (e.g. radio4000.com/{form.slug})</label>
-				<input
-					id="slug"
-					type="text"
-					minLength="4"
-					required
-					onChange={(e) => setForm({...form, [e.target.id]: e.target.value})}
-				/>
+				<input id="slug" type="text" minLength="4" required onChange={bind} />
 			</p>
 			<p>
 				<button type="submit" disabled={loading}>
@@ -57,53 +55,23 @@ export function CreateForm({onSubmit, channel = {}}) {
 }
 
 export function UpdateForm({channel, onSubmit}) {
-	const [loading, setLoading] = useState(false)
-	const [form, setForm] = useState(channel)
-
-	const handleSubmit = async (e) => {
-		e.preventDefault()
-		let res
-		try {
-			setLoading(true)
-			res = await onSubmit(form)
-			if (res.error) throw res.error
-		} catch (error) {
-			console.log(error)
-		} finally {
-			setLoading(false)
-		}
-		return res
-	}
+	const {form, loading, error, bind, handleSubmit} = useForm(channel, {onSubmit})
 
 	return (
 		<form onSubmit={handleSubmit}>
 			<p>
 				<label htmlFor="name">Name</label>
-				<input
-					id="name"
-					type="text"
-					placeholder={channel.name}
-					value={form.name}
-					required
-					onChange={(e) => setForm({...form, [e.target.id]: e.target.value})}
-				/>
+				<input id="name" type="text" value={form.name} required onChange={bind} />
 				<br />
 				<label htmlFor="slug">Slug</label>
-				<input
-					id="slug"
-					type="text"
-					placeholder={channel.slug}
-					value={form.slug}
-					minLength="4"
-					required
-					onChange={(e) => setForm({...form, [e.target.id]: e.target.value})}
-				/>
+				<input id="slug" type="text" value={form.slug} minLength="4" required onChange={bind} />
 			</p>
 			<p>
 				<button type="submit" disabled={loading}>
 					{loading ? 'Loading...' : 'Update'}
 				</button>
 			</p>
+			<ErrorDisplay error={error}></ErrorDisplay>
 		</form>
 	)
 }
@@ -140,7 +108,7 @@ export function DeleteForm({channel, onSubmit}) {
 	return (
 		<form onSubmit={handleSubmit}>
 			<p>
-				To delete your channel, confirm by writing the slug <em>"{channel.slug}"</em>:
+				To delete your channel, confirm by writing <em>"{channel.slug}"</em>:
 			</p>
 			<p>
 				<input
@@ -155,6 +123,7 @@ export function DeleteForm({channel, onSubmit}) {
 					{loading ? 'Loading...' : 'Delete channel'}
 				</button>
 			</p>
+			{/* <ErrorDisplay error={error}></ErrorDisplay> */}
 		</form>
 	)
 }

--- a/src/components/tracks.js
+++ b/src/components/tracks.js
@@ -1,7 +1,8 @@
 import {useState} from 'react'
-import {useTracks, createTrack, updateTrack, deleteTrack} from '../utils/crud/track'
 import useForm from '../hooks/use-form'
+import useTracks from '../hooks/use-tracks'
 import ErrorDisplay from './error-display'
+import {createTrack, updateTrack, deleteTrack} from '../utils/crud/track'
 
 export default function Tracks({channelId, database}) {
 	const {data: tracks, error} = useTracks(channelId, database)

--- a/src/components/tracks.js
+++ b/src/components/tracks.js
@@ -1,5 +1,6 @@
 import {useState} from 'react'
 import {useTracks, createTrack, updateTrack, deleteTrack} from '../utils/crud/track'
+import useForm from '../hooks/use-form'
 import ErrorDisplay from './error-display'
 
 export default function Tracks({channelId, database}) {
@@ -18,31 +19,20 @@ export default function Tracks({channelId, database}) {
 }
 
 export function Track({track, database}) {
-	const [loading, setLoading] = useState(false)
+	const {loading, handleSubmit: handleDelete} = useForm(track, {
+		onSubmit: (track) => deleteTrack({database, track}),
+	})
 	const [editing, setEditing] = useState(false)
-
 	const handleEdit = () => setEditing(!editing)
-
-
-	async function handleDelete(event) {
-		event.preventDefault()
-		console.log('deleting track', track.id)
-		setLoading(true)
-		try {
-			await deleteTrack({database, track})
-			console.log('deleted')
-		} catch (error) {
-			console.error(error)
-			alert(error)
-		} finally {
-			setLoading(false)
-		}
-	}
 
 	return (
 		<article>
 			{editing ? (
-				<UpdateTrackForm database={database} track={track} didUpdate={() => setEditing(false)}></UpdateTrackForm>
+				<UpdateTrackForm
+					database={database}
+					track={track}
+					didUpdate={() => setEditing(false)}
+				></UpdateTrackForm>
 			) : (
 				<p>
 					{track.created_at}
@@ -65,33 +55,15 @@ export function Track({track, database}) {
 }
 
 export function CreateTrackForm({database, userId, channelId}) {
-	const [loading, setLoading] = useState(false)
-	const [form, setForm] = useState({
-		url: 'https://www.youtube.com/watch?v=E3pmkPZIMk0',
-		title: 'Test - Track',
-	})
-	const [error, setError] = useState(false)
-
-	// Shortcut?
-	const bind = (e) => setForm({...form, [e.target.id]: e.target.value})
-
-	const handleSubmit = async (event) => {
-		event.preventDefault()
-		try {
-			setLoading(true)
-			const res = await createTrack({database, data: form, channelId, userId})
-			if (res && res.error) {
-				setError(res.error)
-			} else {
-				setError(false)
-			}
-		} catch (error) {
-			setError(error)
-			throw error
-		} finally {
-			setLoading(false)
+	const {form, loading, error, bind, handleSubmit} = useForm(
+		{
+			url: 'https://www.youtube.com/watch?v=E3pmkPZIMk0',
+			title: 'Test - Track',
+		},
+		{
+			onSubmit: (track) => createTrack({database, track, channelId, userId}),
 		}
-	}
+	)
 
 	return (
 		<form onSubmit={handleSubmit}>
@@ -123,50 +95,27 @@ export function CreateTrackForm({database, userId, channelId}) {
 }
 
 export function UpdateTrackForm({database, track, didUpdate}) {
-	const [form, setForm] = useState(track.track_id)
-	const [loading, setLoading] = useState(false)
-	const [error, setError] = useState(false)
-
-	// Shortcut?
-	const bind = (e) => setForm({...form, [e.target.id]: e.target.value})
-
-	const handleSubmit = async (event) => {
-		event.preventDefault()
-		try {
-			setLoading(true)
-			const res = await updateTrack({database, id: track.id, changes: form})
-			if (res && res.error) {
-				setError(res.error)
-			} else {
-				setError(false)
-			}
-		} catch (error) {
-			setError(error)
-			throw error
-		} finally {
-			setLoading(false)
-			if (!error) didUpdate()
+	const {form, loading, error, bind, handleSubmit} = useForm(
+		{},
+		{
+			onSubmit: (changes) => {
+				updateTrack({database, id: track.id, changes}).then(didUpdate)
+			},
 		}
-	}
+	)
+	const {url, title, description} = track.track_id
 
 	return (
 		<form onSubmit={handleSubmit}>
 			<p>
 				<label htmlFor="name">YouTube or Soundcloud URL</label>
-				<input
-					id="url"
-					type="url"
-					autoFocus={true}
-					defaultValue={track.track_id.url}
-					required
-					onChange={bind}
-				/>
+				<input id="url" type="url" autoFocus={true} defaultValue={url} required onChange={bind} />
 				<br />
 				<label htmlFor="title">Track Title</label>
-				<input id="title" type="text" defaultValue={track.track_id.title} required onChange={bind} />
+				<input id="title" type="text" defaultValue={title} required onChange={bind} />
 				<br />
 				<label htmlFor="description">Description</label>
-				<input id="description" type="text" defaultValue={track.track_id.description} onChange={bind} />
+				<input id="description" type="text" defaultValue={description} onChange={bind} />
 			</p>
 			<p>
 				<button type="submit" disabled={loading}>

--- a/src/hooks/use-channels.js
+++ b/src/hooks/use-channels.js
@@ -1,6 +1,6 @@
 import {useState, useEffect} from 'react'
 
-export default function useChannels (database) {
+export default function useChannels(database) {
 	const [channels, setChannels] = useState([])
 
 	useEffect(() => {
@@ -9,7 +9,7 @@ export default function useChannels (database) {
 			try {
 				res = await database.from('channels').select('*')
 				setChannels(res.data)
-			} catch(e) {
+			} catch (e) {
 				console.log('error fetching channels', e)
 			}
 		}

--- a/src/hooks/use-form.js
+++ b/src/hooks/use-form.js
@@ -1,0 +1,30 @@
+import {useState} from 'react'
+
+export default function useForm(initialState, {onSubmit}) {
+	const [form, setForm] = useState(initialState)
+	const [loading, setLoading] = useState(false)
+	const [error, setError] = useState(false)
+
+	const bind = (e) => setForm({...form, [e.target.id]: e.target.value})
+
+	async function handleSubmit(event) {
+		event?.preventDefault()
+		try {
+			setLoading(true)
+			console.log('submitting', form)
+			const res = await onSubmit(form)
+			console.log(res)
+			if (res && res.error) {
+				setError(res.error)
+			} else {
+				setError(false)
+			}
+		} catch (error) {
+			setError(error)
+		} finally {
+			setLoading(false)
+		}
+	}
+
+	return {form, loading, error, bind, handleSubmit}
+}

--- a/src/hooks/use-form.js
+++ b/src/hooks/use-form.js
@@ -11,9 +11,7 @@ export default function useForm(initialState, {onSubmit}) {
 		event?.preventDefault()
 		try {
 			setLoading(true)
-			console.log('submitting', form)
 			const res = await onSubmit(form)
-			console.log(res)
 			if (res && res.error) {
 				setError(res.error)
 			} else {

--- a/src/hooks/use-tracks.js
+++ b/src/hooks/use-tracks.js
@@ -1,0 +1,26 @@
+import {useState, useEffect} from 'react'
+
+export default function useTracks(channelId, database) {
+	const [tracks, setTracks] = useState([])
+	const [error, setError] = useState(null)
+
+	useEffect(() => {
+		const fetchData = async () => {
+			let res
+			try {
+				res = await database
+					.from('channel_track')
+					.select('id:track_id, created_at, track_id(url, title, description)')
+					.eq('channel_id', channelId)
+				setTracks(res.data)
+				setError(null)
+			} catch (error) {
+				setError(error)
+				console.log('Error fetching tracks', error)
+			}
+		}
+		fetchData()
+	}, [channelId, database])
+
+	return {data: tracks, error}
+}

--- a/src/pages/account.js
+++ b/src/pages/account.js
@@ -41,17 +41,11 @@ export default function Account({dbSession}) {
 								<h2>Manage your channel: {channel.name} (@{channel.slug})</h2>
 								<UpdateForm
 									channel={channel}
-									onSubmit={(updates) => updateChannel({
-										database,
-										channel: updates
-									})}
+									onSubmit={(changes) => updateChannel({database, id: channel.id, changes: {name: 'Oskar'}})}
 								/>
 								<DeleteForm
 									channel={channel}
-									onSubmit={(updates) => deleteChannel({
-										database,
-										channel: updates
-									})}
+									onSubmit={() => deleteChannel({database, id: channel.id})}
 								/>
 							</article>
 						)

--- a/src/pages/account.js
+++ b/src/pages/account.js
@@ -41,7 +41,7 @@ export default function Account({dbSession}) {
 								<h2>Manage your channel: {channel.name} (@{channel.slug})</h2>
 								<UpdateForm
 									channel={channel}
-									onSubmit={(changes) => updateChannel({database, id: channel.id, changes: {name: 'Oskar'}})}
+									onSubmit={(changes) => updateChannel({database, id: channel.id, changes})}
 								/>
 								<DeleteForm
 									channel={channel}

--- a/src/utils/crud/channel.js
+++ b/src/utils/crud/channel.js
@@ -8,7 +8,7 @@ export const createChannel = async ({database, channel, user}) => {
 		.insert({
 			name,
 			slug,
-			user_id
+			user_id,
 		})
 		.single()
 
@@ -25,21 +25,14 @@ export const createChannel = async ({database, channel, user}) => {
 		.single()
 }
 
-export const updateChannel = async ({database, channel}) => {
-	const {id, name, slug} = channel
-	return database
-		.from('channels')
-		.update({
-			name,
-			slug,
-		})
-		.eq('id', id)
-		.single()
+export const updateChannel = async ({database, id, changes}) => {
+	console.log('updating channel', id, changes)
+	const {name, slug} = changes
+	return database.from('channels').update({name, slug}).eq('id', id)
 }
 
-export const deleteChannel = async ({database, channel}) => {
-	const {id} = channel
-	console.log(channel)
+export const deleteChannel = async ({database, id}) => {
 	if (!id) return
-	return database.from('channels').delete().match({id})
+	console.log('deleting channel', id)
+	return database.from('channels').delete().eq('id', id)
 }

--- a/src/utils/crud/track.js
+++ b/src/utils/crud/track.js
@@ -25,8 +25,8 @@ export function useTracks(channelId, database) {
 	return {data: tracks, error}
 }
 
-export const createTrack = async ({database, data, channelId, userId}) => {
-	const {url, title, description} = data
+export const createTrack = async ({database, track, channelId, userId}) => {
+	const {url, title, description} = track
 
 	// Create track
 	const res = await database.from('tracks').insert({url, title, description}).single()
@@ -47,7 +47,6 @@ export const createTrack = async ({database, data, channelId, userId}) => {
 }
 
 export const updateTrack = async ({database, id, changes}) => {
-	// console.log('updating', id, changes)
 	const {url, title, description} = changes
 	return database.from('tracks').update({url, title, description}).eq('id', id)
 }

--- a/src/utils/crud/track.js
+++ b/src/utils/crud/track.js
@@ -1,30 +1,3 @@
-import {useState, useEffect} from 'react'
-
-export function useTracks(channelId, database) {
-	const [tracks, setTracks] = useState([])
-	const [error, setError] = useState(null)
-
-	useEffect(() => {
-		const fetchData = async () => {
-			let res
-			try {
-				res = await database
-					.from('channel_track')
-					.select('id:track_id, created_at, track_id(url, title, description)')
-					.eq('channel_id', channelId)
-				setTracks(res.data)
-				setError(null)
-			} catch (error) {
-				setError(error)
-				console.log('Error fetching tracks', error)
-			}
-		}
-		fetchData()
-	}, [channelId, database])
-
-	return {data: tracks, error}
-}
-
 export const createTrack = async ({database, track, channelId, userId}) => {
 	const {url, title, description} = track
 
@@ -32,7 +5,6 @@ export const createTrack = async ({database, track, channelId, userId}) => {
 	const res = await database.from('tracks').insert({url, title, description}).single()
 
 	// Avoid touching next query (return early) if it did not succeed.
-	// console.log('creating track', res)
 	if (res.error) return res
 
 	// Create junction row

--- a/src/utils/crud/track.js
+++ b/src/utils/crud/track.js
@@ -49,18 +49,10 @@ export const createTrack = async ({database, data, channelId, userId}) => {
 export const updateTrack = async ({database, id, changes}) => {
 	// console.log('updating', id, changes)
 	const {url, title, description} = changes
-	return database
-		.from('tracks')
-		.update({
-			url,
-			title,
-			description
-		})
-		.eq('id', id)
-		.single()
+	return database.from('tracks').update({url, title, description}).eq('id', id)
 }
 
 export const deleteTrack = async ({database, track}) => {
 	if (!track.id) return
-	return database.from('tracks').delete().match({id: track.id})
+	return database.from('tracks').delete().eq('id', track.id)
 }


### PR DESCRIPTION
Playing around with our own `useForm` hook (after talking to the falxa) that removes boilerplate around fetching something async while handling error + loading states.

Refactored the channel and track forms with it.

Here's an example of how to use the hook:

```js
function ExampleForm({database, apiCall}) {
	const {form, loading, error, bind, handleSubmit} = useForm(
		{title: 'Hello World'},
		{onSubmit: apiCall}
	)

	return (
		<form onSubmit={handleSubmit}>
			<p>
				<label htmlFor="title">Title</label>
				<input id="title" type="text" defaultValue={form.title} required onChange={bind} />
			</p>
			<p>
				<button type="submit" disabled={loading}>
					{loading ? 'Loading...' : 'Create track'}
				</button>
			</p>
			<ErrorDisplay error={error}></ErrorDisplay>
		</form>
	)
}
```